### PR TITLE
Update scikit-learn Compatibility to version 1.3.2 (current stable version)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages = find:
 package_dir =
     = src
 install_requires =
-    scikit-learn>=0.21.3,<1.2.2
+    scikit-learn>=0.21.3
     scipy
     joblib
 

--- a/src/ml2json/classification.py
+++ b/src/ml2json/classification.py
@@ -384,6 +384,8 @@ def deserialize_tree(tree_dict, n_features, n_classes, n_outputs):
     tree_dict['nodes'] = [tuple(lst) for lst in tree_dict['nodes']]
 
     names = ['left_child', 'right_child', 'feature', 'threshold', 'impurity', 'n_node_samples', 'weighted_n_node_samples']
+    if sklearn.__version__ >= '1.3':
+        names.append('missing_go_to_left')
     tree_dict['nodes'] = np.array(tree_dict['nodes'], dtype=np.dtype({'names': names, 'formats': tree_dict['nodes_dtype']}))
     tree_dict['values'] = np.array(tree_dict['values'])
 

--- a/src/ml2json/classification.py
+++ b/src/ml2json/classification.py
@@ -1114,7 +1114,7 @@ def serialize_isolation_forest(model):
         'estimator_params': list(model.estimator_params),
         'params': model.get_params()
     }
-
+    
     if 'base_estimator_' in model.__dict__ and model.base_estimator_ is not None:
         serialized_model['base_estimator_'] = (inspect.getmodule(model.base_estimator_).__name__,
                                                type(model.base_estimator_).__name__,
@@ -1130,6 +1130,12 @@ def serialize_isolation_forest(model):
 
     if 'feature_names_in_' in model.__dict__:
         serialized_model['feature_names_in_'] = model.feature_names_in_.tolist()
+
+    if '_decision_path_lengths' in model.__dict__:
+        serialized_model['_decision_path_lengths'] = [array.tolist() for array in model._decision_path_lengths]
+        
+    if '_average_path_length_per_tree' in model.__dict__:
+        serialized_model['_average_path_length_per_tree'] = [array.tolist() for array in model._average_path_length_per_tree]
 
     return serialized_model
 
@@ -1168,6 +1174,12 @@ def deserialize_isolation_forest(model_dict):
 
     if 'feature_names_in_' in model_dict.keys():
         model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+        
+    if '_decision_path_lengths' in model_dict.keys():
+        model._decision_path_lengths = tuple([np.array(array) for array in model_dict['_decision_path_lengths']])
+    
+    if '_average_path_length_per_tree' in model_dict.keys():
+        model._average_path_length_per_tree = tuple([np.array(array) for array in model_dict['_average_path_length_per_tree']])
 
     return model
 

--- a/src/ml2json/cross_decomposition.py
+++ b/src/ml2json/cross_decomposition.py
@@ -14,7 +14,6 @@ def serialize_cca(model):
         'y_loadings_': model.y_loadings_.tolist(),
         'x_rotations_': model.x_rotations_.tolist(),
         'y_rotations_': model.y_rotations_.tolist(),
-        '_coef_': model._coef_.tolist(),
         'intercept_': model.intercept_.tolist(),
         'n_iter_': model.n_iter_,
         'n_features_in_': model.n_features_in_,
@@ -34,6 +33,14 @@ def serialize_cca(model):
 
     if 'feature_names_in_' in model.__dict__:
         serialized_model['feature_names_in_'] = model.feature_names_in_.tolist()
+    
+    if '_coef_' in model.__dict__:
+        serialized_model['_coef_'] = model._coef_.tolist()
+    else:
+        serialized_model['coef_'] = model.coef_.tolist()
+        
+    if "_predict_1d" in model.__dict__:
+        serialized_model["_predict_1d"] = model._predict_1d
 
     return serialized_model
 
@@ -47,7 +54,6 @@ def deserialize_cca(model_dict):
     model.y_loadings_ = np.array(model_dict['y_loadings_'])
     model.x_rotations_ = np.array(model_dict['x_rotations_'])
     model.y_rotations_ = np.array(model_dict['y_rotations_'])
-    model._coef_ = np.array(model_dict['_coef_'])
     model.intercept_ = np.array(model_dict['intercept_'])
     model.n_iter_ = model_dict['n_iter_']
     model.n_features_in_ = model_dict['n_features_in_']
@@ -67,6 +73,14 @@ def deserialize_cca(model_dict):
     if 'feature_names_in_' in model_dict.keys():
         model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
 
+    if '_coef_' in model_dict.keys():
+        model._coef_ = np.array(model_dict['_coef_'])
+    else:
+        model.coef_ = np.array(model_dict['coef_'])
+       
+    if "_predict_1d" in model_dict.keys():
+        model._predict_1d = model_dict["_predict_1d"]
+
     return model
 
 
@@ -79,7 +93,6 @@ def serialize_pls_canonical(model):
         'y_loadings_': model.y_loadings_.tolist(),
         'x_rotations_': model.x_rotations_.tolist(),
         'y_rotations_': model.y_rotations_.tolist(),
-        '_coef_': model._coef_.tolist(),
         'intercept_': model.intercept_.tolist(),
         'n_iter_': model.n_iter_,
         'n_features_in_': model.n_features_in_,
@@ -98,6 +111,14 @@ def serialize_pls_canonical(model):
 
     if 'feature_names_in_' in model.__dict__:
         serialized_model['feature_names_in_'] = model.feature_names_in_.tolist()
+    
+    if '_coef_' in model.__dict__:
+        serialized_model['_coef_'] = model._coef_.tolist()
+    else:
+        serialized_model['coef_'] = model.coef_.tolist()
+        
+    if "_predict_1d" in model.__dict__:
+        serialized_model["_predict_1d"] = model._predict_1d
 
     return serialized_model
 
@@ -111,7 +132,6 @@ def deserialize_pls_canonical(model_dict):
     model.y_loadings_ = np.array(model_dict['y_loadings_'])
     model.x_rotations_ = np.array(model_dict['x_rotations_'])
     model.y_rotations_ = np.array(model_dict['y_rotations_'])
-    model._coef_ = np.array(model_dict['_coef_'])
     model.intercept_ = np.array(model_dict['intercept_'])
     model.n_iter_ = model_dict['n_iter_']
     model.n_features_in_ = model_dict['n_features_in_']
@@ -129,6 +149,14 @@ def deserialize_pls_canonical(model_dict):
 
     if 'feature_names_in_' in model_dict.keys():
         model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+    
+    if '_coef_' in model_dict.keys():
+        model._coef_ = np.array(model_dict['_coef_'])
+    else:
+        model.coef_ = np.array(model_dict['coef_'])
+        
+    if "_predict_1d" in model_dict.keys():
+        model._predict_1d = model_dict["_predict_1d"]
 
     return model
 
@@ -142,7 +170,6 @@ def serialize_pls_regression(model):
         'y_loadings_': model.y_loadings_.tolist(),
         'x_rotations_': model.x_rotations_.tolist(),
         'y_rotations_': model.y_rotations_.tolist(),
-        '_coef_': model._coef_.tolist(),
         'intercept_': model.intercept_.tolist(),
         'n_iter_': model.n_iter_,
         'n_features_in_': model.n_features_in_,
@@ -164,6 +191,14 @@ def serialize_pls_regression(model):
     if 'feature_names_in_' in model.__dict__:
         serialized_model['feature_names_in_'] = model.feature_names_in_.tolist()
 
+    if '_coef_' in model.__dict__:
+        serialized_model['_coef_'] = model._coef_.tolist()
+    else:
+        serialized_model['coef_'] = model.coef_.tolist()
+        
+    if "_predict_1d" in model.__dict__:
+        serialized_model["_predict_1d"] = model._predict_1d
+
     return serialized_model
 
 
@@ -176,7 +211,6 @@ def deserialize_pls_regression(model_dict):
     model.y_loadings_ = np.array(model_dict['y_loadings_'])
     model.x_rotations_ = np.array(model_dict['x_rotations_'])
     model.y_rotations_ = np.array(model_dict['y_rotations_'])
-    model._coef_ = np.array(model_dict['_coef_'])
     model.intercept_ = np.array(model_dict['intercept_'])
     model.n_iter_ = model_dict['n_iter_']
     model.n_features_in_ = model_dict['n_features_in_']
@@ -196,6 +230,14 @@ def deserialize_pls_regression(model_dict):
 
     if 'feature_names_in_' in model_dict.keys():
         model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+        
+    if '_coef_' in model_dict.keys():
+        model._coef_ = np.array(model_dict['_coef_'])
+    else:
+        model.coef_ = np.array(model_dict['coef_'])
+    
+    if "_predict_1d" in model_dict.keys():
+        model._predict_1d = model_dict["_predict_1d"]
 
     return model
 

--- a/src/ml2json/decomposition.py
+++ b/src/ml2json/decomposition.py
@@ -159,13 +159,17 @@ def serialize_fast_ica(model):
         'whitening_': model.whitening_.tolist(),
         'mean_': model.mean_.tolist(),
         'n_iter_': model.n_iter_,
-        '_whiten': model._whiten,
         'n_features_in_': model.n_features_in_,
         'params': model.get_params(),
     }
 
     if 'feature_names_in_' in model.__dict__:
         serialized_model['feature_names_in_'] = model.feature_names_in_.tolist()
+        
+    if '_whiten' in model.__dict__:
+        serialized_model['_whiten'] = model._whiten
+    else:
+        serialized_model['whiten'] = model.whiten
 
     return serialized_model
 
@@ -178,11 +182,15 @@ def deserialize_fast_ica(model_dict):
     model.whitening_ = np.array(model_dict['whitening_'])
     model.mean_ = np.array(model_dict['mean_'])
     model.n_iter_ = model_dict['n_iter_']
-    model._whiten = model_dict['_whiten']
     model.n_features_in_ = model_dict['n_features_in_']
 
     if 'feature_names_in_' in model_dict.keys():
         model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+
+    if '_whiten' in model_dict.keys():
+        model._whiten = model_dict['_whiten']
+    else:
+        model.whithen = model_dict['whiten']
 
     return model
 

--- a/src/ml2json/decomposition.py
+++ b/src/ml2json/decomposition.py
@@ -69,6 +69,9 @@ def serialize_kernel_pca(model):
     if 'feature_names_in_' in model.__dict__:
         serialized_model['feature_names_in_'] = model.feature_names_in_.tolist()
 
+    if 'gamma_' in model.__dict__:
+        serialized_model['gamma_'] = model.gamma_
+
     return serialized_model
 
 
@@ -83,6 +86,9 @@ def deserialize_kernel_pca(model_dict):
 
     if 'feature_names_in_' in model_dict.keys():
         model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+
+    if 'gamma_' in model_dict.keys():
+        model.gamma_ = model_dict['gamma_']
 
     return model
 

--- a/src/ml2json/preprocessing.py
+++ b/src/ml2json/preprocessing.py
@@ -203,6 +203,9 @@ def serialize_onehot_encoder(model):
 
     serialized_model['params']['dtype'] = (inspect.getmodule(serialized_model['params']['dtype']).__name__,
                                            serialized_model['params']['dtype'].__name__)
+    
+    if '_drop_idx_after_grouping' in model.__dict__: 
+        serialized_model['_drop_idx_after_grouping'] = model._drop_idx_after_grouping.tolist() if model._drop_idx_after_grouping is not None else None
 
     return serialized_model
 
@@ -219,5 +222,8 @@ def deserialize_onehot_encoder(model_dict):
     model._infrequent_enabled = model_dict['_infrequent_enabled']
     model.n_features_in_ = model_dict['n_features_in_']
     model._n_features_outs = model_dict['_n_features_outs']
+    
+    if '_drop_idx_after_grouping' in model_dict.keys():
+        model._drop_idx_after_grouping = np.array(model_dict['_drop_idx_after_grouping']) if model_dict['_drop_idx_after_grouping'] is not None else None
 
     return model

--- a/src/ml2json/regression.py
+++ b/src/ml2json/regression.py
@@ -263,6 +263,8 @@ def deserialize_tree(tree_dict, n_features, n_outputs):
     tree_dict['nodes'] = [tuple(lst) for lst in tree_dict['nodes']]
 
     names = ['left_child', 'right_child', 'feature', 'threshold', 'impurity', 'n_node_samples', 'weighted_n_node_samples']
+    if sklearn.__version__ >= '1.3':
+        names.append('missing_go_to_left')
     tree_dict['nodes'] = np.array(tree_dict['nodes'], dtype=np.dtype({'names': names, 'formats': tree_dict['nodes_dtype']}))
     tree_dict['values'] = np.array(tree_dict['values'])
 


### PR DESCRIPTION
# Pull Request: Update scikit-learn Compatibility to version 1.3.2 (current version)

## Description

This pull request updates the repository to be compatible with scikit-learn version 1.2.2 and later.
All unit tests pass for version scikit-learn version 1.3.2 (also still pass for version 1.2.2)

## Changes Made
- Added item `missing_go_to_left` for tree based models
- Added attributes `_decision_path_lengths` and `_average_path_length_per_tree` for `IsolationForest`
- Renamed attribute `_coef_` to `coef_` and added attribute `_predict_1d` in module `cross_decomposition` for `CCA`, `PLSCanonical` and  `PLSRegression`.
- Added attribute `_drop_idx_after_grouping` for `OneHotEncoder`
- Renamed attribute `_whiten` to `whiten` for `fastICA`
- Added `gamma_` attribute for KernelPCA
- Removed requirement scikit-learn version <1.2.2 from setup.cfg
