### PR TITLE
Add MLChemAD to ml2json

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ ml2json requires scikit-learn >= 0.21.3.
 | Scikit-Learn       | Naive Bayes                               | naive_bayes.MultinomialNB                           | :heavy_check_mark: |
 | Scikit-Learn       | Nearest Neighbors                         | neighbors.BallTree                                  |        :x:         |
 | Scikit-Learn       | Nearest Neighbors                         | neighbors.KDTree                                    | :heavy_check_mark: |
-| Scikit-Learn       | Nearest Neighbors                         | neighbors.KernelDensity                             |        :x:         |
-| Scikit-Learn       | Nearest Neighbors                         | neighbors.KNeighborsClassifier                      |        :x:         |
-| Scikit-Learn       | Nearest Neighbors                         | neighbors.KNeighborsRegressor                       |        :x:         |
+| Scikit-Learn       | Nearest Neighbors                         | neighbors.KernelDensity                             | :heavy_check_mark: |
+| Scikit-Learn       | Nearest Neighbors                         | neighbors.KNeighborsClassifier                      | :heavy_check_mark: |
+| Scikit-Learn       | Nearest Neighbors                         | neighbors.KNeighborsRegressor                       | :heavy_check_mark: |
 | Scikit-Learn       | Nearest Neighbors                         | neighbors.KNeighborsTransformer                     |        :x:         |
 | Scikit-Learn       | Nearest Neighbors                         | neighbors.LocalOutlierFactor                        |        :x:         |
 | Scikit-Learn       | Nearest Neighbors                         | neighbors.RadiusNeighborsClassifier                 |        :x:         |
@@ -248,7 +248,7 @@ ml2json requires scikit-learn >= 0.21.3.
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.LabelBinarizer                        | :heavy_check_mark: |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.LabelEncoder                          | :heavy_check_mark: |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.MultiLabelBinarizer                   | :heavy_check_mark: |
-| Scikit-Learn       | Preprocessing and Normalization           | preprocessing.MaxAbsScaler                          |        :x:         |
+| Scikit-Learn       | Preprocessing and Normalization           | preprocessing.MaxAbsScaler                          | :heavy_check_mark: |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.MinMaxScaler                          | :heavy_check_mark: |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.Normalizer                            |        :x:         |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.OneHotEncoder                         | :heavy_check_mark: |
@@ -256,7 +256,7 @@ ml2json requires scikit-learn >= 0.21.3.
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.PolynomialFeatures                    |        :x:         |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.PowerTransformer                      |        :x:         |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.QuantileTransformer                   |        :x:         |
-| Scikit-Learn       | Preprocessing and Normalization           | preprocessing.RobustScaler                          |        :x:         |
+| Scikit-Learn       | Preprocessing and Normalization           | preprocessing.RobustScaler                          | :heavy_check_mark: |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.SplineTransformer                     |        :x:         |
 | Scikit-Learn       | Preprocessing and Normalization           | preprocessing.StandardScaler                        | :heavy_check_mark: |
 | Scikit-Learn       | Random projection                         | random_projection.GaussianRandomProjection          |        :x:         |
@@ -330,3 +330,14 @@ ml2json requires scikit-learn >= 0.21.3.
 | Prince             | Decomposition                             | MFA                                                 |        :x:         |
 | Prince             | Decomposition                             | FAMD                                                |        :x:         |
 | Prince             | Decomposition                             | GPA                                                 |        :x:         |
+| MLChemAD           | Applicability Domain                      | BoundingBoxApplicabilityDomain                      | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | ConvexHullApplicabilityDomain                       | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | PCABoundingBoxApplicabilityDomain                   | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | TopKatApplicabilityDomain                           | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | LeverageApplicabilityDomain                         | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | HotellingT2ApplicabilityDomain                      | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | KernelDensityApplicabilityDomain                    | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | IsolationForestApplicabilityDomain                  | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | CentroidDistanceApplicabilityDomain                 | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | KNNApplicabilityDomain                              | :heavy_check_mark: |
+| MLChemAD           | Applicability Domain                      | StandardizationApproachApplicabilityDomain          | :heavy_check_mark: |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ In addition of the support for scikit-learn models, ml2json supports the followi
 - UMAP
 - PyNNDescent
 - Prince
+- MlChemAD
 
 ml2json requires scikit-learn >= 0.21.3.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ full =
     pynndescent
     umap-learn
     kmodes
+    mlchemad
 
 docs =
     sphinx

--- a/src/ml2json/__init__.py
+++ b/src/ml2json/__init__.py
@@ -23,7 +23,7 @@ from sklearn.linear_model import LinearRegression, Lasso, Ridge, ElasticNet
 from sklearn.neural_network import MLPClassifier, MLPRegressor
 from sklearn.preprocessing import (LabelEncoder, LabelBinarizer, MultiLabelBinarizer,
                                    MinMaxScaler, StandardScaler, KernelCenterer,
-                                   OneHotEncoder)
+                                   OneHotEncoder, RobustScaler, MaxAbsScaler)
 from sklearn.svm import SVR
 from sklearn.cluster import (AffinityPropagation, AgglomerativeClustering,
                              Birch, DBSCAN, FeatureAgglomeration, KMeans,
@@ -409,6 +409,12 @@ def serialize_model(model, catboost_data: Pool = None) -> Dict:
     elif isinstance(model, StandardScaler):
         model_dict = pre.serialize_standard_scaler(model)
         return serialize_version(model, model_dict)
+    elif isinstance(model, RobustScaler):
+        model_dict = pre.serialize_robust_scaler(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, MaxAbsScaler):
+        model_dict = pre.serialize_maxabs_scaler(model)
+        return serialize_version(model, model_dict)
     elif isinstance(model, KernelCenterer):
         model_dict = pre.serialize_kernel_centerer(model)
         return serialize_version(model, model_dict)
@@ -780,6 +786,12 @@ def deserialize_model(model_dict: Dict):
     elif model_dict['meta'] == 'standard-scaler':
         check_version(model_dict)
         return pre.deserialize_standard_scaler(model_dict)
+    elif model_dict['meta'] == 'robust-scaler':
+        check_version(model_dict)
+        return pre.deserialize_robust_scaler(model_dict)
+    elif model_dict['meta'] == 'maxabs-scaler':
+        check_version(model_dict)
+        return pre.deserialize_maxabs_scaler(model_dict)
     elif model_dict['meta'] == 'kernel-centerer':
         check_version(model_dict)
         return pre.deserialize_kernel_centerer(model_dict)

--- a/src/ml2json/__init__.py
+++ b/src/ml2json/__init__.py
@@ -46,7 +46,8 @@ from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
                                             KernelDensityApplicabilityDomain,
                                             IsolationForestApplicabilityDomain,
                                             CentroidDistanceApplicabilityDomain,
-                                            KNNApplicabilityDomain)
+                                            KNNApplicabilityDomain,
+                                            StandardizationApproachApplicabilityDomain)
 
 from . import classification as clf
 from . import regression as reg
@@ -443,9 +444,9 @@ def serialize_model(model, catboost_data: Pool = None) -> Dict:
     elif isinstance(model, KNNApplicabilityDomain):
         model_dict = ad.serialize_knn_applicability_domain(model)
         return serialize_version(model, model_dict)
-    # elif isinstance(model, StandardizationApproachApplicabilityDomain):
-    #     model_dict = ad.serialize_standardization_approach_applicability_domain(model)
-    #     return serialize_version(model, model_dict)
+    elif isinstance(model, StandardizationApproachApplicabilityDomain):
+        model_dict = ad.serialize_standardization_approach_applicability_domain(model)
+        return serialize_version(model, model_dict)
 
     # Otherwise
     else:
@@ -811,9 +812,9 @@ def deserialize_model(model_dict: Dict):
     elif model_dict['meta'] == 'knn-ad':
         check_version(model_dict)
         return ad.deserialize_knn_applicability_domain(model_dict)
-    # elif model_dict['meta'] == 'standardization-approach-ad':
-    #     check_version(model_dict)
-    #     return ad.deserialize_standardization_approach_applicability_domain(model_dict)   
+    elif model_dict['meta'] == 'standardization-approach-ad':
+        check_version(model_dict)
+        return ad.deserialize_standardization_approach_applicability_domain(model_dict)   
 
     # Otherwise
     else:

--- a/src/ml2json/__init__.py
+++ b/src/ml2json/__init__.py
@@ -46,8 +46,7 @@ from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
                                             KernelDensityApplicabilityDomain,
                                             IsolationForestApplicabilityDomain,
                                             CentroidDistanceApplicabilityDomain,
-                                            KNNApplicabilityDomain,
-                                            StandardizationApproachApplicabilityDomain)
+                                            KNNApplicabilityDomain)
 
 from . import classification as clf
 from . import regression as reg
@@ -444,9 +443,9 @@ def serialize_model(model, catboost_data: Pool = None) -> Dict:
     elif isinstance(model, KNNApplicabilityDomain):
         model_dict = ad.serialize_knn_applicability_domain(model)
         return serialize_version(model, model_dict)
-    elif isinstance(model, StandardizationApproachApplicabilityDomain):
-        model_dict = ad.serialize_standardization_approach_applicability_domain(model)
-        return serialize_version(model, model_dict)
+    # elif isinstance(model, StandardizationApproachApplicabilityDomain):
+    #     model_dict = ad.serialize_standardization_approach_applicability_domain(model)
+    #     return serialize_version(model, model_dict)
 
     # Otherwise
     else:
@@ -812,9 +811,9 @@ def deserialize_model(model_dict: Dict):
     elif model_dict['meta'] == 'knn-ad':
         check_version(model_dict)
         return ad.deserialize_knn_applicability_domain(model_dict)
-    elif model_dict['meta'] == 'standardization-approach-ad':
-        check_version(model_dict)
-        return ad.deserialize_standardization_approach_applicability_domain(model_dict)   
+    # elif model_dict['meta'] == 'standardization-approach-ad':
+    #     check_version(model_dict)
+    #     return ad.deserialize_standardization_approach_applicability_domain(model_dict)   
 
     # Otherwise
     else:

--- a/src/ml2json/__init__.py
+++ b/src/ml2json/__init__.py
@@ -37,6 +37,17 @@ from sklearn.decomposition import (PCA, KernelPCA, DictionaryLearning, FactorAna
 from sklearn.manifold import (Isomap, LocallyLinearEmbedding,
                               MDS, SpectralEmbedding, TSNE)
 from sklearn.neighbors import NearestNeighbors, KDTree, KNeighborsClassifier, KNeighborsRegressor
+from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
+                                            ConvexHullApplicabilityDomain,
+                                            PCABoundingBoxApplicabilityDomain,
+                                            TopKatApplicabilityDomain,
+                                            LeverageApplicabilityDomain,
+                                            HotellingT2ApplicabilityDomain,
+                                            KernelDensityApplicabilityDomain,
+                                            IsolationForestApplicabilityDomain,
+                                            CentroidDistanceApplicabilityDomain,
+                                            KNNApplicabilityDomain,
+                                            StandardizationApproachApplicabilityDomain)
 
 from . import classification as clf
 from . import regression as reg
@@ -47,6 +58,7 @@ from . import decomposition as dec
 from . import manifold as man
 from . import neighbors as nei
 from . import cross_decomposition as crdec
+from . import applicability_domain as ad
 from .utils import is_model_fitted
 
 # Make additional dependencies optional
@@ -400,6 +412,41 @@ def serialize_model(model, catboost_data: Pool = None) -> Dict:
     elif isinstance(model, OneHotEncoder):
         model_dict = pre.serialize_onehot_encoder(model)
         return serialize_version(model, model_dict)
+    
+    # Applicability Domain
+    elif isinstance(model, BoundingBoxApplicabilityDomain):
+        model_dict = ad.serialize_bounding_box_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, ConvexHullApplicabilityDomain):
+        model_dict = ad.serialize_convex_hull_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, PCABoundingBoxApplicabilityDomain):
+        model_dict = ad.serialize_pca_bounding_box_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, TopKatApplicabilityDomain):
+        model_dict = ad.serialize_topkat_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, LeverageApplicabilityDomain):
+        model_dict = ad.serialize_leverage_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, HotellingT2ApplicabilityDomain):
+        model_dict = ad.serialize_hotelling_t2_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, KernelDensityApplicabilityDomain):
+        model_dict = ad.serialize_kernel_density_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, IsolationForestApplicabilityDomain):
+        model_dict = ad.serialize_isolation_forest_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, CentroidDistanceApplicabilityDomain):
+        model_dict = ad.serialize_centroid_distance_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, KNNApplicabilityDomain):
+        model_dict = ad.serialize_knn_applicability_domain(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, StandardizationApproachApplicabilityDomain):
+        model_dict = ad.serialize_standardization_approach_applicability_domain(model)
+        return serialize_version(model, model_dict)
 
     # Otherwise
     else:
@@ -733,6 +780,41 @@ def deserialize_model(model_dict: Dict):
     elif model_dict['meta'] == 'onehot-encoder':
         check_version(model_dict)
         return pre.deserialize_onehot_encoder(model_dict)
+    
+    # Applicability Domain
+    elif model_dict['meta'] == 'bounding-box-ad':
+        check_version(model_dict)
+        return ad.deserialize_bounding_box_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'convex-hull-ad':
+        check_version(model_dict)
+        return ad.deserialize_convex_hull_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'pca-bounding-box-ad':
+        check_version(model_dict)
+        return ad.deserialize_pca_bounding_box_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'topkat-ad':
+        check_version(model_dict)
+        return ad.deserialize_topkat_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'leverage-ad':
+        check_version(model_dict)
+        return ad.deserialize_leverage_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'hotelling-t2-ad':
+        check_version(model_dict)
+        return ad.deserialize_hotelling_t2_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'kernel-density-ad':
+        check_version(model_dict)
+        return ad.deserialize_kernel_density_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'isolation-forest-ad':
+        check_version(model_dict)
+        return ad.deserialize_isolation_forest_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'centroid-distance-ad':
+        check_version(model_dict)
+        return ad.deserialize_centroid_distance_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'knn-ad':
+        check_version(model_dict)
+        return ad.deserialize_knn_applicability_domain(model_dict)
+    elif model_dict['meta'] == 'standardization-approach-ad':
+        check_version(model_dict)
+        return ad.deserialize_standardization_approach_applicability_domain(model_dict)   
 
     # Otherwise
     else:

--- a/src/ml2json/__init__.py
+++ b/src/ml2json/__init__.py
@@ -37,17 +37,6 @@ from sklearn.decomposition import (PCA, KernelPCA, DictionaryLearning, FactorAna
 from sklearn.manifold import (Isomap, LocallyLinearEmbedding,
                               MDS, SpectralEmbedding, TSNE)
 from sklearn.neighbors import NearestNeighbors, KDTree, KNeighborsClassifier, KNeighborsRegressor, KernelDensity
-from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
-                                            ConvexHullApplicabilityDomain,
-                                            PCABoundingBoxApplicabilityDomain,
-                                            TopKatApplicabilityDomain,
-                                            LeverageApplicabilityDomain,
-                                            HotellingT2ApplicabilityDomain,
-                                            KernelDensityApplicabilityDomain,
-                                            IsolationForestApplicabilityDomain,
-                                            CentroidDistanceApplicabilityDomain,
-                                            KNNApplicabilityDomain,
-                                            StandardizationApproachApplicabilityDomain)
 
 from . import classification as clf
 from . import regression as reg
@@ -80,6 +69,18 @@ if 'NNDescent' in nei.__optionals__:
     from pynndescent import NNDescent
 if 'UMAP' in man.__optionals__:
     from umap import UMAP
+if 'BoundingBoxApplicabilityDomain' in ad.__optionals__:
+    from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
+                                                ConvexHullApplicabilityDomain,
+                                                PCABoundingBoxApplicabilityDomain,
+                                                TopKatApplicabilityDomain,
+                                                LeverageApplicabilityDomain,
+                                                HotellingT2ApplicabilityDomain,
+                                                KernelDensityApplicabilityDomain,
+                                                IsolationForestApplicabilityDomain,
+                                                CentroidDistanceApplicabilityDomain,
+                                                KNNApplicabilityDomain,
+                                                StandardizationApproachApplicabilityDomain)
 
 
 __version__ = '0.2.2'

--- a/src/ml2json/__init__.py
+++ b/src/ml2json/__init__.py
@@ -36,7 +36,7 @@ from sklearn.decomposition import (PCA, KernelPCA, DictionaryLearning, FactorAna
                                    MiniBatchNMF, SparsePCA, SparseCoder, TruncatedSVD)
 from sklearn.manifold import (Isomap, LocallyLinearEmbedding,
                               MDS, SpectralEmbedding, TSNE)
-from sklearn.neighbors import NearestNeighbors, KDTree, KNeighborsClassifier, KNeighborsRegressor
+from sklearn.neighbors import NearestNeighbors, KDTree, KNeighborsClassifier, KNeighborsRegressor, KernelDensity
 from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
                                             ConvexHullApplicabilityDomain,
                                             PCABoundingBoxApplicabilityDomain,
@@ -380,6 +380,9 @@ def serialize_model(model, catboost_data: Pool = None) -> Dict:
         return serialize_version(model, model_dict)
     elif isinstance(model, KDTree):
         model_dict = nei.serialize_kdtree(model)
+        return serialize_version(model, model_dict)
+    elif isinstance(model, KernelDensity):
+        model_dict = nei.serialize_kernel_density(model)
         return serialize_version(model, model_dict)
     elif 'NNDescent' in nei.__optionals__ and isinstance(model, NNDescent):
         model_dict = nei.serialize_nndescent(model)
@@ -749,6 +752,9 @@ def deserialize_model(model_dict: Dict):
     elif model_dict['meta'] == 'kdtree':
         check_version(model_dict)
         return  nei.deserialize_kdtree(model_dict)
+    elif model_dict['meta'] == 'kernel-density':
+        check_version(model_dict)
+        return  nei.deserialize_kernel_density(model_dict)
     elif model_dict['meta'] == 'nn-descent':
         check_version(model_dict)
         return  nei.deserialize_nndescent(model_dict)

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -250,18 +250,32 @@ def deserialize_kernel_density_applicability_domain(model_dict):
     return model
 
 def serialize_isolation_forest_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'isolation-forest-ad',
-    # }
+    serialized_model = {
+        'meta': 'isolation-forest-ad',
+        'fitted_': model.fitted_,
+        'isol': ml2json.to_dict(model.isol),
+    }
     
-    # return serialized_model
-    return NotImplementedError
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            }
+        )
+    
+    return serialized_model
 
 def deserialize_isolation_forest_applicability_domain(model_dict):
-    # model = IsolationForestApplicabilityDomain()
+    model = IsolationForestApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.isol = ml2json.from_dict(model_dict['isol'])
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_centroid_distance_applicability_domain(model):
     # serialized_model = {

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -156,32 +156,66 @@ def deserialize_topkat_applicability_domain(model_dict):
     return model
 
 def serialize_leverage_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'leverage-ad',
-    # }
+    serialized_model = {
+        'meta': 'leverage-ad',
+        'fitted_': model.fitted_,
+        'scaler': ml2json.to_dict(model.scaler),
+    }
     
-    # return serialized_model
-    return NotImplementedError
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            'var_covar': model.var_covar.tolist(),
+            'threshold': model.threshold,
+            }
+        )
+    
+    return serialized_model
 
 def deserialize_leverage_applicability_domain(model_dict):
-    # model = LeverageApplicabilityDomain()
+    model = LeverageApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.scaler = ml2json.from_dict(model_dict['scaler'])
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.var_covar = np.array(model_dict['var_covar'])
+        model.threshold = model_dict['threshold']
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_hotelling_t2_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'hotelling-t2-ad',
-    # }
+    serialized_model = {
+        'meta': 'hotelling-t2-ad',
+        'fitted_': model.fitted_,
+        'alpha': model.alpha,
+    }
     
-    # return serialized_model
-    return NotImplementedError
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            't2': model.t2.tolist(),
+            }
+        )
+    
+    return serialized_model
 
 def deserialize_hotelling_t2_applicability_domain(model_dict):
-    # model = HotellingT2ApplicabilityDomain()
+    model = HotellingT2ApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.alpha = model_dict['alpha']
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.t2 = np.array(model_dict['t2'])
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_kernel_density_applicability_domain(model):
     # serialized_model = {

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -15,7 +15,8 @@ from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
                                             KernelDensityApplicabilityDomain,
                                             IsolationForestApplicabilityDomain,
                                             CentroidDistanceApplicabilityDomain,
-                                            KNNApplicabilityDomain)
+                                            KNNApplicabilityDomain,
+                                            StandardizationApproachApplicabilityDomain)
 
 
 def serialize_bounding_box_applicability_domain(model):
@@ -354,15 +355,29 @@ def deserialize_knn_applicability_domain(model_dict):
     return model
 
 def serialize_standardization_approach_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'standardization-approach-ad',
-    # }
+    serialized_model = {
+        'meta': 'standardization-approach-ad',
+        'fitted_': model.fitted_,
+        'scaler': ml2json.to_dict(model.scaler),
+    }
     
-    # return serialized_model
-    return NotImplementedError
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            }
+        )
+    
+    return serialized_model
 
 def deserialize_standardization_approach_applicability_domain(model_dict):
-    # model = StandardizationApproachApplicabilityDomain()
+    model = StandardizationApproachApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.scaler = ml2json.from_dict(model_dict['scaler'])
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
 
-    # return model
-    return NotImplementedError
+    return model

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -278,18 +278,38 @@ def deserialize_isolation_forest_applicability_domain(model_dict):
     return model
 
 def serialize_centroid_distance_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'centroid-distance-ad',
-    # }
+    serialized_model = {
+        'meta': 'centroid-distance-ad',
+        'fitted_': model.fitted_,
+        'dist': model.dist,
+        'scaler': ml2json.to_dict(model.scaler),
+        'threshold': model.threshold if model.threshold is not None else None,
+    }
     
-    # return serialized_model
-    return NotImplementedError
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            'centroid': model.centroid.tolist(),
+            }
+        )
+    
+    return serialized_model
 
 def deserialize_centroid_distance_applicability_domain(model_dict):
-    # model = CentroidDistanceApplicabilityDomain()
+    model = CentroidDistanceApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.dist = model_dict['dist']
+    model.scaler = ml2json.from_dict(model_dict['scaler'])
+    model.threshold = model_dict['threshold']
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.centroid = np.array(model_dict['centroid'])
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_knn_applicability_domain(model):
     # serialized_model = {

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -56,18 +56,31 @@ def deserialize_bounding_box_applicability_domain(model_dict):
     return model
 
 def serialize_convex_hull_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'convex-hull-ad',
-    # }
+    serialized_model = {
+        'meta': 'convex-hull-ad',
+        'fitted_': model.fitted_,
+    }
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            'points': model.points.tolist(),
+            }
+        )
     
-    # return serialized_model
-    return NotImplementedError
+    return serialized_model
 
 def deserialize_convex_hull_applicability_domain(model_dict):
-    # model = ConvexHullApplicabilityDomain()
+    model = ConvexHullApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.points = np.array(model_dict['points'])
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_pca_bounding_box_applicability_domain(model):
     # serialized_model = {

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -312,18 +312,46 @@ def deserialize_centroid_distance_applicability_domain(model_dict):
     return model
 
 def serialize_knn_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'knn-ad',
-    # }
+    serialized_model = {
+        'meta': 'knn-ad',
+        'fitted_': model.fitted_,
+        'scaler': ml2json.to_dict(model.scaler),
+        'dist': model.dist,
+        'k': model.k,
+        'alpha': model.alpha,
+        'hard_threshold': model.hard_threshold,
+    }
     
-    # return serialized_model
-    return NotImplementedError
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            'X_norm': model.X_norm.tolist(),
+            'kNN_dist': model.kNN_dist.tolist(),
+            'threshold_': model.threshold_,
+            }
+        )
+    
+    return serialized_model
 
 def deserialize_knn_applicability_domain(model_dict):
-    # model = KNNApplicabilityDomain()
+    model = KNNApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.scaler = ml2json.from_dict(model_dict['scaler'])
+    model.dist = model_dict['dist']
+    model.k = model_dict['k']
+    model.alpha = model_dict['alpha']
+    model.hard_threshold = model_dict['hard_threshold']
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.X_norm = np.array(model_dict['X_norm'])
+        model.kNN_dist = np.array(model_dict['kNN_dist'])
+        model.threshold_ = model_dict['threshold_']
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_standardization_approach_applicability_domain(model):
     # serialized_model = {

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -119,18 +119,41 @@ def deserialize_pca_bounding_box_applicability_domain(model_dict):
     return model
 
 def serialize_topkat_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'topkat-ad',
-    # }
+    serialized_model = {
+        'meta': 'topkat-ad',
+        'fitted_': model.fitted_,
+    }
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            'X_min_' : model.X_min_.tolist(),
+            'X_max_' : model.X_max_.tolist(),
+            'eigen_val': model.eigen_val.tolist(),
+            'eigen_vec': model.eigen_vec.tolist(),
+            'OPS_min_': model.OPS_min_.tolist(),
+            'OPS_max_': model.OPS_max_.tolist(),
+            }
+        )
     
-    # return serialized_model
-    return NotImplementedError
+    return serialized_model
 
 def deserialize_topkat_applicability_domain(model_dict):
-    # model = TopKatApplicabilityDomain()
+    model = TopKatApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.X_min_ = np.array(model_dict['X_min_'])
+        model.X_max_ = np.array(model_dict['X_max_'])
+        model.eigen_val = np.array(model_dict['eigen_val'])
+        model.eigen_vec = np.array(model_dict['eigen_vec'])
+        model.OPS_min_ = np.array(model_dict['OPS_min_'])
+        model.OPS_max_ = np.array(model_dict['OPS_max_'])
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_leverage_applicability_domain(model):
     # serialized_model = {

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -2,6 +2,7 @@
 
 import inspect
 import importlib
+import ml2json
 
 import numpy as np
 
@@ -83,18 +84,39 @@ def deserialize_convex_hull_applicability_domain(model_dict):
     return model
 
 def serialize_pca_bounding_box_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'pca-bounding-box-ad',
-    # }
+    serialized_model = {
+        'meta': 'pca-bounding-box-ad',
+        'fitted_': model.fitted_,
+        'scaler': ml2json.to_dict(model.scaler),
+        'min_explained_var': model.min_explained_var,
+        'pca': ml2json.to_dict(model.pca),
+    }
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            'min_': model.min_.tolist(),
+            'max_': model.max_.tolist(),
+            }
+        )
     
-    # return serialized_model
-    return NotImplementedError
+    return serialized_model
 
 def deserialize_pca_bounding_box_applicability_domain(model_dict):
-    # model = PCABoundingBoxApplicabilityDomain()
+    model = PCABoundingBoxApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.scaler = ml2json.from_dict(model_dict['scaler'])
+    model.min_explained_var = model_dict['min_explained_var']
+    model.pca = ml2json.from_dict(model_dict['pca'])
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.min_ = np.array(model_dict['min_'])
+        model.max_ = np.array(model_dict['max_'])
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_topkat_applicability_domain(model):
     # serialized_model = {

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -218,18 +218,36 @@ def deserialize_hotelling_t2_applicability_domain(model_dict):
     return model
 
 def serialize_kernel_density_applicability_domain(model):
-    # serialized_model = {
-    #     'meta': 'kernel-density-ad',
-    # }
+    serialized_model = {
+        'meta': 'kernel-density-ad',
+        'fitted_': model.fitted_,
+        'kde': ml2json.to_dict(model.kde), # TODO: add ml2json.to_dict(model.kde)
+        'threshold': model.threshold,
+    }
     
-    # return serialized_model
-    return NotImplementedError
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            'cutoff': model.cutoff,
+            }
+        )
+    
+    return serialized_model
 
 def deserialize_kernel_density_applicability_domain(model_dict):
-    # model = KernelDensityApplicabilityDomain()
+    model = KernelDensityApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.kde = ml2json.from_dict(model_dict['kde'])
+    model.threshold = model_dict['threshold']
+    
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.cutoff = model_dict['cutoff']
 
-    # return model
-    return NotImplementedError
+    return model
 
 def serialize_isolation_forest_applicability_domain(model):
     # serialized_model = {

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -3,17 +3,33 @@
 import ml2json
 import numpy as np
 
-from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
-                                            ConvexHullApplicabilityDomain,
-                                            PCABoundingBoxApplicabilityDomain,
-                                            TopKatApplicabilityDomain,
-                                            LeverageApplicabilityDomain,
-                                            HotellingT2ApplicabilityDomain,
-                                            KernelDensityApplicabilityDomain,
-                                            IsolationForestApplicabilityDomain,
-                                            CentroidDistanceApplicabilityDomain,
-                                            KNNApplicabilityDomain,
-                                            StandardizationApproachApplicabilityDomain)
+# Allow additional dependencies to be optional
+__optionals__ = []
+try:
+    from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
+                                                ConvexHullApplicabilityDomain,
+                                                PCABoundingBoxApplicabilityDomain,
+                                                TopKatApplicabilityDomain,
+                                                LeverageApplicabilityDomain,
+                                                HotellingT2ApplicabilityDomain,
+                                                KernelDensityApplicabilityDomain,
+                                                IsolationForestApplicabilityDomain,
+                                                CentroidDistanceApplicabilityDomain,
+                                                KNNApplicabilityDomain,
+                                                StandardizationApproachApplicabilityDomain)
+    __optionals__.extend(['BoundingBoxApplicabilityDomain',
+                            'ConvexHullApplicabilityDomain',
+                            'PCABoundingBoxApplicabilityDomain',
+                            'TopKatApplicabilityDomain',
+                            'LeverageApplicabilityDomain',
+                            'HotellingT2ApplicabilityDomain',
+                            'KernelDensityApplicabilityDomain',
+                            'IsolationForestApplicabilityDomain',
+                            'CentroidDistanceApplicabilityDomain',
+                            'KNNApplicabilityDomain',
+                            'StandardizationApproachApplicabilityDomain'])
+except ImportError:
+    pass
 
 
 def serialize_bounding_box_applicability_domain(model):
@@ -37,22 +53,23 @@ def serialize_bounding_box_applicability_domain(model):
 
     return serialized_model
 
-def deserialize_bounding_box_applicability_domain(model_dict):
-    model = BoundingBoxApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.compute_minmax = model_dict['compute_minmax']
-    model.constant_value_min = model_dict['constant_value_min']
-    model.constant_value_max = model_dict['constant_value_max']
-    model.percentiles_min_max = (tuple(model_dict['percentiles_min_max']) 
-                                 if model_dict['percentiles_min_max'] else None)
+if 'BoundingBoxApplicabilityDomain' in __optionals__:
+    def deserialize_bounding_box_applicability_domain(model_dict):
+        model = BoundingBoxApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.compute_minmax = model_dict['compute_minmax']
+        model.constant_value_min = model_dict['constant_value_min']
+        model.constant_value_max = model_dict['constant_value_max']
+        model.percentiles_min_max = (tuple(model_dict['percentiles_min_max']) 
+                                    if model_dict['percentiles_min_max'] else None)
 
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.min_ = np.array(model_dict['min_'])
-        model.max_ = np.array(model_dict['max_'])
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.min_ = np.array(model_dict['min_'])
+            model.max_ = np.array(model_dict['max_'])
 
-    return model
+        return model
 
 def serialize_convex_hull_applicability_domain(model):
     serialized_model = {
@@ -70,16 +87,17 @@ def serialize_convex_hull_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_convex_hull_applicability_domain(model_dict):
-    model = ConvexHullApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.points = np.array(model_dict['points'])
+if 'ConvexHullApplicabilityDomain' in __optionals__:
+    def deserialize_convex_hull_applicability_domain(model_dict):
+        model = ConvexHullApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.points = np.array(model_dict['points'])
 
-    return model
+        return model
 
 def serialize_pca_bounding_box_applicability_domain(model):
     serialized_model = {
@@ -101,20 +119,21 @@ def serialize_pca_bounding_box_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_pca_bounding_box_applicability_domain(model_dict):
-    model = PCABoundingBoxApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.scaler = ml2json.from_dict(model_dict['scaler'])
-    model.min_explained_var = model_dict['min_explained_var']
-    model.pca = ml2json.from_dict(model_dict['pca'])
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.min_ = np.array(model_dict['min_'])
-        model.max_ = np.array(model_dict['max_'])
+if 'PCABoundingBoxApplicabilityDomain' in __optionals__:
+    def deserialize_pca_bounding_box_applicability_domain(model_dict):
+        model = PCABoundingBoxApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.scaler = ml2json.from_dict(model_dict['scaler'])
+        model.min_explained_var = model_dict['min_explained_var']
+        model.pca = ml2json.from_dict(model_dict['pca'])
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.min_ = np.array(model_dict['min_'])
+            model.max_ = np.array(model_dict['max_'])
 
-    return model
+        return model
 
 def serialize_topkat_applicability_domain(model):
     serialized_model = {
@@ -137,21 +156,22 @@ def serialize_topkat_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_topkat_applicability_domain(model_dict):
-    model = TopKatApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.X_min_ = np.array(model_dict['X_min_'])
-        model.X_max_ = np.array(model_dict['X_max_'])
-        model.eigen_val = np.array(model_dict['eigen_val'])
-        model.eigen_vec = np.array(model_dict['eigen_vec'])
-        model.OPS_min_ = np.array(model_dict['OPS_min_'])
-        model.OPS_max_ = np.array(model_dict['OPS_max_'])
+if 'TopKatApplicabilityDomain' in __optionals__:
+    def deserialize_topkat_applicability_domain(model_dict):
+        model = TopKatApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.X_min_ = np.array(model_dict['X_min_'])
+            model.X_max_ = np.array(model_dict['X_max_'])
+            model.eigen_val = np.array(model_dict['eigen_val'])
+            model.eigen_vec = np.array(model_dict['eigen_vec'])
+            model.OPS_min_ = np.array(model_dict['OPS_min_'])
+            model.OPS_max_ = np.array(model_dict['OPS_max_'])
 
-    return model
+        return model
 
 def serialize_leverage_applicability_domain(model):
     serialized_model = {
@@ -172,18 +192,19 @@ def serialize_leverage_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_leverage_applicability_domain(model_dict):
-    model = LeverageApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.scaler = ml2json.from_dict(model_dict['scaler'])
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.var_covar = np.array(model_dict['var_covar'])
-        model.threshold = model_dict['threshold']
+if 'LeverageApplicabilityDomain' in __optionals__:
+    def deserialize_leverage_applicability_domain(model_dict):
+        model = LeverageApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.scaler = ml2json.from_dict(model_dict['scaler'])
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.var_covar = np.array(model_dict['var_covar'])
+            model.threshold = model_dict['threshold']
 
-    return model
+        return model
 
 def serialize_hotelling_t2_applicability_domain(model):
     serialized_model = {
@@ -203,17 +224,18 @@ def serialize_hotelling_t2_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_hotelling_t2_applicability_domain(model_dict):
-    model = HotellingT2ApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.alpha = model_dict['alpha']
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.t2 = np.array(model_dict['t2'])
+if 'HotellingT2ApplicabilityDomain' in __optionals__:
+    def deserialize_hotelling_t2_applicability_domain(model_dict):
+        model = HotellingT2ApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.alpha = model_dict['alpha']
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.t2 = np.array(model_dict['t2'])
 
-    return model
+        return model
 
 def serialize_kernel_density_applicability_domain(model):
     serialized_model = {
@@ -234,18 +256,19 @@ def serialize_kernel_density_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_kernel_density_applicability_domain(model_dict):
-    model = KernelDensityApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.kde = ml2json.from_dict(model_dict['kde'])
-    model.threshold = model_dict['threshold']
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.cutoff = model_dict['cutoff']
+if 'KernelDensityApplicabilityDomain' in __optionals__:
+    def deserialize_kernel_density_applicability_domain(model_dict):
+        model = KernelDensityApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.kde = ml2json.from_dict(model_dict['kde'])
+        model.threshold = model_dict['threshold']
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.cutoff = model_dict['cutoff']
 
-    return model
+        return model
 
 def serialize_isolation_forest_applicability_domain(model):
     serialized_model = {
@@ -264,16 +287,17 @@ def serialize_isolation_forest_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_isolation_forest_applicability_domain(model_dict):
-    model = IsolationForestApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.isol = ml2json.from_dict(model_dict['isol'])
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
+if 'IsolationForestApplicabilityDomain' in __optionals__:
+    def deserialize_isolation_forest_applicability_domain(model_dict):
+        model = IsolationForestApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.isol = ml2json.from_dict(model_dict['isol'])
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
 
-    return model
+        return model
 
 def serialize_centroid_distance_applicability_domain(model):
     serialized_model = {
@@ -295,19 +319,20 @@ def serialize_centroid_distance_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_centroid_distance_applicability_domain(model_dict):
-    model = CentroidDistanceApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.dist = model_dict['dist']
-    model.scaler = ml2json.from_dict(model_dict['scaler'])
-    model.threshold = model_dict['threshold']
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.centroid = np.array(model_dict['centroid'])
+if 'CentroidDistanceApplicabilityDomain' in __optionals__:
+    def deserialize_centroid_distance_applicability_domain(model_dict):
+        model = CentroidDistanceApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.dist = model_dict['dist']
+        model.scaler = ml2json.from_dict(model_dict['scaler'])
+        model.threshold = model_dict['threshold']
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.centroid = np.array(model_dict['centroid'])
 
-    return model
+        return model
 
 def serialize_knn_applicability_domain(model):
     serialized_model = {
@@ -333,25 +358,26 @@ def serialize_knn_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_knn_applicability_domain(model_dict):
-    model = KNNApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.scaler = (ml2json.from_dict(model_dict['scaler'])
-                    if model_dict['scaler'] is not None
-                    else None)
-    model.dist = model_dict['dist']
-    model.k = model_dict['k']
-    model.alpha = model_dict['alpha']
-    model.hard_threshold = model_dict['hard_threshold']
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
-        model.X_norm = np.array(model_dict['X_norm'])
-        model.kNN_dist = np.array(model_dict['kNN_dist'])
-        model.threshold_ = model_dict['threshold_']
+if 'KNNApplicabilityDomain' in __optionals__:
+    def deserialize_knn_applicability_domain(model_dict):
+        model = KNNApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.scaler = (ml2json.from_dict(model_dict['scaler'])
+                        if model_dict['scaler'] is not None
+                        else None)
+        model.dist = model_dict['dist']
+        model.k = model_dict['k']
+        model.alpha = model_dict['alpha']
+        model.hard_threshold = model_dict['hard_threshold']
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
+            model.X_norm = np.array(model_dict['X_norm'])
+            model.kNN_dist = np.array(model_dict['kNN_dist'])
+            model.threshold_ = model_dict['threshold_']
 
-    return model
+        return model
 
 def serialize_standardization_approach_applicability_domain(model):
     serialized_model = {
@@ -370,13 +396,14 @@ def serialize_standardization_approach_applicability_domain(model):
     
     return serialized_model
 
-def deserialize_standardization_approach_applicability_domain(model_dict):
-    model = StandardizationApproachApplicabilityDomain()
-    model.fitted_ = model_dict['fitted_']
-    model.scaler = ml2json.from_dict(model_dict['scaler'])
-    
-    if model.fitted_:
-        model.num_points = model_dict['num_points']
-        model.num_dims = model_dict['num_dims']
+if 'StandardizationApproachApplicabilityDomain' in __optionals__:
+    def deserialize_standardization_approach_applicability_domain(model_dict):
+        model = StandardizationApproachApplicabilityDomain()
+        model.fitted_ = model_dict['fitted_']
+        model.scaler = ml2json.from_dict(model_dict['scaler'])
+        
+        if model.fitted_:
+            model.num_points = model_dict['num_points']
+            model.num_dims = model_dict['num_dims']
 
-    return model
+        return model

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import inspect
-import importlib
 import ml2json
-
 import numpy as np
 
 from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
@@ -316,7 +313,7 @@ def serialize_knn_applicability_domain(model):
     serialized_model = {
         'meta': 'knn-ad',
         'fitted_': model.fitted_,
-        'scaler': ml2json.to_dict(model.scaler),
+        'scaler': ml2json.to_dict(model.scaler) if model.scaler is not None else None,
         'dist': model.dist,
         'k': model.k,
         'alpha': model.alpha,
@@ -339,7 +336,9 @@ def serialize_knn_applicability_domain(model):
 def deserialize_knn_applicability_domain(model_dict):
     model = KNNApplicabilityDomain()
     model.fitted_ = model_dict['fitted_']
-    model.scaler = ml2json.from_dict(model_dict['scaler'])
+    model.scaler = (ml2json.from_dict(model_dict['scaler'])
+                    if model_dict['scaler'] is not None
+                    else None)
     model.dist = model_dict['dist']
     model.k = model_dict['k']
     model.alpha = model_dict['alpha']

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -14,19 +14,44 @@ from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
                                             KernelDensityApplicabilityDomain,
                                             IsolationForestApplicabilityDomain,
                                             CentroidDistanceApplicabilityDomain,
-                                            KNNApplicabilityDomain,
-                                            StandardizationApproachApplicabilityDomain)
+                                            KNNApplicabilityDomain)
 
 
 def serialize_bounding_box_applicability_domain(model):
     serialized_model = {
         'meta': 'bounding-box-ad',
+        'fitted_': model.fitted_,
+        'compute_minmax': model.compute_minmax,
+        'constant_value_min': model.constant_value_min,
+        'constant_value_max': model.constant_value_max,
+        'percentiles_min_max': model.percentiles_min_max,
     }
-    
+    if model.fitted_:
+        serialized_model.update(
+            {
+            'num_points': model.num_points,
+            'num_dims': model.num_dims,
+            'min_': model.min_.tolist(),
+            'max_': model.max_.tolist(),
+            }
+        )
+
     return serialized_model
 
 def deserialize_bounding_box_applicability_domain(model_dict):
     model = BoundingBoxApplicabilityDomain()
+    model.fitted_ = model_dict['fitted_']
+    model.compute_minmax = model_dict['compute_minmax']
+    model.constant_value_min = model_dict['constant_value_min']
+    model.constant_value_max = model_dict['constant_value_max']
+    model.percentiles_min_max = (tuple(model_dict['percentiles_min_max']) 
+                                 if model_dict['percentiles_min_max'] else None)
+
+    if model.fitted_:
+        model.num_points = model_dict['num_points']
+        model.num_dims = model_dict['num_dims']
+        model.min_ = np.array(model_dict['min_'])
+        model.max_ = np.array(model_dict['max_'])
 
     return model
 

--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+
+import inspect
+import importlib
+
+import numpy as np
+
+from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
+                                            ConvexHullApplicabilityDomain,
+                                            PCABoundingBoxApplicabilityDomain,
+                                            TopKatApplicabilityDomain,
+                                            LeverageApplicabilityDomain,
+                                            HotellingT2ApplicabilityDomain,
+                                            KernelDensityApplicabilityDomain,
+                                            IsolationForestApplicabilityDomain,
+                                            CentroidDistanceApplicabilityDomain,
+                                            KNNApplicabilityDomain,
+                                            StandardizationApproachApplicabilityDomain)
+
+
+def serialize_bounding_box_applicability_domain(model):
+    serialized_model = {
+        'meta': 'bounding-box-ad',
+    }
+    
+    return serialized_model
+
+def deserialize_bounding_box_applicability_domain(model_dict):
+    model = BoundingBoxApplicabilityDomain()
+
+    return model
+
+def serialize_convex_hull_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'convex-hull-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_convex_hull_applicability_domain(model_dict):
+    # model = ConvexHullApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_pca_bounding_box_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'pca-bounding-box-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_pca_bounding_box_applicability_domain(model_dict):
+    # model = PCABoundingBoxApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_topkat_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'topkat-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_topkat_applicability_domain(model_dict):
+    # model = TopKatApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_leverage_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'leverage-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_leverage_applicability_domain(model_dict):
+    # model = LeverageApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_hotelling_t2_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'hotelling-t2-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_hotelling_t2_applicability_domain(model_dict):
+    # model = HotellingT2ApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_kernel_density_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'kernel-density-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_kernel_density_applicability_domain(model_dict):
+    # model = KernelDensityApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_isolation_forest_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'isolation-forest-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_isolation_forest_applicability_domain(model_dict):
+    # model = IsolationForestApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_centroid_distance_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'centroid-distance-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_centroid_distance_applicability_domain(model_dict):
+    # model = CentroidDistanceApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_knn_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'knn-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_knn_applicability_domain(model_dict):
+    # model = KNNApplicabilityDomain()
+
+    # return model
+    return NotImplementedError
+
+def serialize_standardization_approach_applicability_domain(model):
+    # serialized_model = {
+    #     'meta': 'standardization-approach-ad',
+    # }
+    
+    # return serialized_model
+    return NotImplementedError
+
+def deserialize_standardization_approach_applicability_domain(model_dict):
+    # model = StandardizationApproachApplicabilityDomain()
+
+    # return model
+    return NotImplementedError

--- a/src/ml2json/decomposition.py
+++ b/src/ml2json/decomposition.py
@@ -17,7 +17,7 @@ def serialize_pca(model):
         'explained_variance_ratio_': model.explained_variance_ratio_.tolist(),
         'singular_values_': model.singular_values_.tolist(),
         'mean_': model.mean_.tolist(),
-        'n_components_': model.n_components_,
+        'n_components_': int(model.n_components_),
         'n_samples_': model.n_samples_,
         'noise_variance_': model.noise_variance_,
         'n_features_in_': model.n_features_in_,

--- a/src/ml2json/neighbors.py
+++ b/src/ml2json/neighbors.py
@@ -4,7 +4,7 @@ import inspect
 import importlib
 
 import numpy as np
-from sklearn.neighbors import NearestNeighbors, KDTree
+from sklearn.neighbors import NearestNeighbors, KDTree, KernelDensity
 
 # Allow additional dependencies to be optional
 __optionals__ = []
@@ -58,6 +58,39 @@ def deserialize_nearest_neighbors(model_dict):
 
     return model
 
+
+def serialize_kernel_density(model):
+    serialized_model = {
+        'meta': 'kernel-density',
+        'bandwidth_': model.bandwidth_,
+        'n_features_in_': model.n_features_in_,
+        'params': model.get_params(),
+    }
+    
+    if 'feature_names_in_' in model.__dict__:
+        serialized_model['feature_names_in_'] = model.feature_names_in_.tolist()
+    if model.tree_ is not None:
+        serialized_model['tree_'] = serialize_kdtree(model.tree_)
+    else:
+        serialized_model['tree_'] = model.tree_
+
+    return serialized_model
+
+def deserialize_kernel_density(model_dict):
+    model = KernelDensity(**model_dict['params'])
+
+    model.bandwidth_ = model_dict['bandwidth_']
+    model.n_features_in_ = model_dict['n_features_in_']
+
+    if 'feature_names_in_' in model_dict.keys():
+        model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+    if model_dict['tree_'] is not None:
+        model.tree_ = deserialize_kdtree(model_dict['tree_'])
+    else:
+        model.tree_ = model_dict['tree_']
+
+    return model
+    
 
 def serialize_kdtree(model):
     state = model.__getstate__()

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -3,19 +3,35 @@ import unittest
 
 import numpy as np
 from sklearn.datasets import fetch_california_housing
-from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
-                                            ConvexHullApplicabilityDomain,
-                                            PCABoundingBoxApplicabilityDomain,
-                                            TopKatApplicabilityDomain,
-                                            LeverageApplicabilityDomain,
-                                            HotellingT2ApplicabilityDomain,
-                                            KernelDensityApplicabilityDomain,
-                                            IsolationForestApplicabilityDomain,
-                                            CentroidDistanceApplicabilityDomain,
-                                            KNNApplicabilityDomain,
-                                            StandardizationApproachApplicabilityDomain)
-
 from src import ml2json
+
+# Allow additional dependencies to be optional
+__optionals__ = []
+try:
+    from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
+                                                ConvexHullApplicabilityDomain,
+                                                PCABoundingBoxApplicabilityDomain,
+                                                TopKatApplicabilityDomain,
+                                                LeverageApplicabilityDomain,
+                                                HotellingT2ApplicabilityDomain,
+                                                KernelDensityApplicabilityDomain,
+                                                IsolationForestApplicabilityDomain,
+                                                CentroidDistanceApplicabilityDomain,
+                                                KNNApplicabilityDomain,
+                                                StandardizationApproachApplicabilityDomain)
+    __optionals__.extend(['BoundingBoxApplicabilityDomain',
+                            'ConvexHullApplicabilityDomain',
+                            'PCABoundingBoxApplicabilityDomain',
+                            'TopKatApplicabilityDomain',
+                            'LeverageApplicabilityDomain',
+                            'HotellingT2ApplicabilityDomain',
+                            'KernelDensityApplicabilityDomain',
+                            'IsolationForestApplicabilityDomain',
+                            'CentroidDistanceApplicabilityDomain',
+                            'KNNApplicabilityDomain',
+                            'StandardizationApproachApplicabilityDomain'])
+except ImportError:
+    pass
 
 class TestAPI(unittest.TestCase):
 
@@ -41,7 +57,8 @@ class TestAPI(unittest.TestCase):
                     actual_c = deserialized_model.contains(self.X)
 
                     np.testing.assert_array_equal(expected_c, actual_c)
-            
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')
     def test_bounding_box_applicability_domain(self):
         model = BoundingBoxApplicabilityDomain()
         self.check_applicability_domain(model, 'bounding-box-ad.json')
@@ -55,46 +72,56 @@ class TestAPI(unittest.TestCase):
         # check with percentiles is None
         model = BoundingBoxApplicabilityDomain(percentiles=None)
         self.check_applicability_domain(model, 'bounding-box-ad.json')
-        
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')
     def test_convex_hull_applicability_domain(self):
         model = ConvexHullApplicabilityDomain()
         self.check_applicability_domain(model, 'convex-hull-ad.json')
-        
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')   
     def test_pca_bounding_box_applicability_domain(self):
         model = PCABoundingBoxApplicabilityDomain()
         self.check_applicability_domain(model, 'pca-bounding-box-ad.json')
-        
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')   
     def test_topkat_applicability_domain(self):
         model = TopKatApplicabilityDomain()
         self.check_applicability_domain(model, 'topkat-ad.json')
-        
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')   
     def test_leverage_applicability_domain(self):
         model = LeverageApplicabilityDomain()
         self.check_applicability_domain(model, 'leverage-ad.json')
-        
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')
     def test_hotelling_t2_applicability_domain(self):
         model = HotellingT2ApplicabilityDomain()
         self.check_applicability_domain(model, 'hotelling-t2-ad.json')
 
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')
     def test_kernel_density_applicability_domain(self):
         model = KernelDensityApplicabilityDomain()
         self.check_applicability_domain(model, 'kernel-density-ad.json')
     
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')
     def test_isolation_forest_applicability_domain(self):
         model = IsolationForestApplicabilityDomain()
         self.check_applicability_domain(model, 'isolation-forest-ad.json')
-        
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.') 
     def test_centroid_distance_applicability_domain(self):
         model = CentroidDistanceApplicabilityDomain()
         self.check_applicability_domain(model, 'centroid-distance-ad.json')
-        
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.') 
     def test_knn_applicability_domain(self):
         model = KNNApplicabilityDomain()
         self.check_applicability_domain(model, 'knn-ad.json')
         
         model = KNNApplicabilityDomain(scaling=None)
         self.check_applicability_domain(model, 'knn-ad.json')
-        
+    
+    @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')
     def test_standardization_approach_applicability_domain(self):
         model = StandardizationApproachApplicabilityDomain()
         self.check_applicability_domain(model, 'standardization-approach-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -63,3 +63,7 @@ class TestAPI(unittest.TestCase):
         # TODO add robust scaler and maxabsscaler to ml2json
         model = PCABoundingBoxApplicabilityDomain(scaling='standard')
         self.check_applicability_domain(model, 'pca-bounding-box-ad.json')
+        
+    def test_topkat_applicability_domain(self):
+        model = TopKatApplicabilityDomain()
+        self.check_applicability_domain(model, 'topkat-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -80,3 +80,7 @@ class TestAPI(unittest.TestCase):
     # def test_kernel_density_applicability_domain(self):
     #     model = KernelDensityApplicabilityDomain()
     #     self.check_applicability_domain(model, 'kernel-density-ad.json')
+    
+    def test_isolation_forest_applicability_domain(self):
+        model = IsolationForestApplicabilityDomain()
+        self.check_applicability_domain(model, 'isolation-forest-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -84,3 +84,7 @@ class TestAPI(unittest.TestCase):
     def test_isolation_forest_applicability_domain(self):
         model = IsolationForestApplicabilityDomain()
         self.check_applicability_domain(model, 'isolation-forest-ad.json')
+        
+    def test_centroid_distance_applicability_domain(self):
+        model = CentroidDistanceApplicabilityDomain()
+        self.check_applicability_domain(model, 'centroid-distance-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -12,7 +12,8 @@ from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
                                             KernelDensityApplicabilityDomain,
                                             IsolationForestApplicabilityDomain,
                                             CentroidDistanceApplicabilityDomain,
-                                            KNNApplicabilityDomain)
+                                            KNNApplicabilityDomain,
+                                            StandardizationApproachApplicabilityDomain)
 
 from src import ml2json
 
@@ -92,3 +93,7 @@ class TestAPI(unittest.TestCase):
     def test_knn_applicability_domain(self):
         model = KNNApplicabilityDomain(scaling='standard')
         self.check_applicability_domain(model, 'knn-ad.json')
+        
+    def test_standardization_approach_applicability_domain(self):
+        model = StandardizationApproachApplicabilityDomain()
+        self.check_applicability_domain(model, 'standardization-approach-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -60,5 +60,6 @@ class TestAPI(unittest.TestCase):
         self.check_applicability_domain(model, 'convex-hull-ad.json')
         
     def test_pca_bounding_box_applicability_domain(self):
+        # TODO add robust scaler and maxabsscaler to ml2json
         model = PCABoundingBoxApplicabilityDomain(scaling='standard')
         self.check_applicability_domain(model, 'pca-bounding-box-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -89,7 +89,10 @@ class TestAPI(unittest.TestCase):
         self.check_applicability_domain(model, 'centroid-distance-ad.json')
         
     def test_knn_applicability_domain(self):
-        model = KNNApplicabilityDomain(scaling='standard')
+        model = KNNApplicabilityDomain()
+        self.check_applicability_domain(model, 'knn-ad.json')
+        
+        model = KNNApplicabilityDomain(scaling=None)
         self.check_applicability_domain(model, 'knn-ad.json')
         
     def test_standardization_approach_applicability_domain(self):

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -1,0 +1,43 @@
+import os
+import unittest
+
+import numpy as np
+from sklearn.datasets import fetch_california_housing
+from mlchemad.applicability_domains import (BoundingBoxApplicabilityDomain,
+                                            ConvexHullApplicabilityDomain,
+                                            PCABoundingBoxApplicabilityDomain,
+                                            TopKatApplicabilityDomain,
+                                            LeverageApplicabilityDomain,
+                                            HotellingT2ApplicabilityDomain,
+                                            KernelDensityApplicabilityDomain,
+                                            IsolationForestApplicabilityDomain,
+                                            CentroidDistanceApplicabilityDomain,
+                                            KNNApplicabilityDomain,
+                                            StandardizationApproachApplicabilityDomain)
+
+from src import ml2json
+
+class TestAPI(unittest.TestCase):
+
+    def setUp(self):
+        self.X = fetch_california_housing()['data']
+        
+    def check_applicability_domain(self, applicability_domain, model_name):
+        applicability_domain.fit(self.X)
+        expected_c = applicability_domain.contains(self.X)
+
+        serialized_dict_model = ml2json.to_dict(applicability_domain)
+        deserialized_dict_model = ml2json.from_dict(serialized_dict_model)
+
+        ml2json.to_json(applicability_domain, model_name)
+        deserialized_json_model = ml2json.from_json(model_name)
+        os.remove(model_name)
+
+        for deserialized_model in [deserialized_dict_model, deserialized_json_model]:
+            actual_c = deserialized_model.contains(self.X)
+
+            np.testing.assert_array_equal(expected_c, actual_c)
+            
+    def test_bounding_box_applicability_domain(self):
+        model = BoundingBoxApplicabilityDomain()
+        self.check_applicability_domain(model, 'bounding-box-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -19,7 +19,8 @@ from src import ml2json
 class TestAPI(unittest.TestCase):
 
     def setUp(self):
-        self.X = fetch_california_housing()['data']
+        # take only the first 1000 samples
+        self.X = fetch_california_housing()['data'][:1000]
         
     def check_applicability_domain(self, applicability_domain, model_name):
         for fit in [True, False]:
@@ -53,3 +54,7 @@ class TestAPI(unittest.TestCase):
         # check with percentiles is None
         model = BoundingBoxApplicabilityDomain(percentiles=None)
         self.check_applicability_domain(model, 'bounding-box-ad.json')
+        
+    def test_convex_hull_applicability_domain(self):
+        model = ConvexHullApplicabilityDomain()
+        self.check_applicability_domain(model, 'convex-hull-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -76,11 +76,10 @@ class TestAPI(unittest.TestCase):
     def test_hotelling_t2_applicability_domain(self):
         model = HotellingT2ApplicabilityDomain()
         self.check_applicability_domain(model, 'hotelling-t2-ad.json')
-        
-    # TODO add kde to ml2json
-    # def test_kernel_density_applicability_domain(self):
-    #     model = KernelDensityApplicabilityDomain()
-    #     self.check_applicability_domain(model, 'kernel-density-ad.json')
+
+    def test_kernel_density_applicability_domain(self):
+        model = KernelDensityApplicabilityDomain()
+        self.check_applicability_domain(model, 'kernel-density-ad.json')
     
     def test_isolation_forest_applicability_domain(self):
         model = IsolationForestApplicabilityDomain()

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -88,3 +88,7 @@ class TestAPI(unittest.TestCase):
     def test_centroid_distance_applicability_domain(self):
         model = CentroidDistanceApplicabilityDomain()
         self.check_applicability_domain(model, 'centroid-distance-ad.json')
+        
+    def test_knn_applicability_domain(self):
+        model = KNNApplicabilityDomain(scaling='standard')
+        self.check_applicability_domain(model, 'knn-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -26,20 +26,20 @@ class TestAPI(unittest.TestCase):
         for fit in [True, False]:
             if fit:
                 applicability_domain.fit(self.X)
-        expected_c = applicability_domain.contains(self.X)
+            expected_c = applicability_domain.contains(self.X)
 
-        serialized_dict_model = ml2json.to_dict(applicability_domain)
-        deserialized_dict_model = ml2json.from_dict(serialized_dict_model)
+            serialized_dict_model = ml2json.to_dict(applicability_domain)
+            deserialized_dict_model = ml2json.from_dict(serialized_dict_model)
 
-        ml2json.to_json(applicability_domain, model_name)
-        deserialized_json_model = ml2json.from_json(model_name)
-        os.remove(model_name)
+            ml2json.to_json(applicability_domain, model_name)
+            deserialized_json_model = ml2json.from_json(model_name)
+            os.remove(model_name)
 
-        if fit:
-            for deserialized_model in [deserialized_dict_model, deserialized_json_model]:
-                actual_c = deserialized_model.contains(self.X)
+            if fit:
+                for deserialized_model in [deserialized_dict_model, deserialized_json_model]:
+                    actual_c = deserialized_model.contains(self.X)
 
-                np.testing.assert_array_equal(expected_c, actual_c)
+                    np.testing.assert_array_equal(expected_c, actual_c)
             
     def test_bounding_box_applicability_domain(self):
         model = BoundingBoxApplicabilityDomain()
@@ -58,3 +58,7 @@ class TestAPI(unittest.TestCase):
     def test_convex_hull_applicability_domain(self):
         model = ConvexHullApplicabilityDomain()
         self.check_applicability_domain(model, 'convex-hull-ad.json')
+        
+    def test_pca_bounding_box_applicability_domain(self):
+        model = PCABoundingBoxApplicabilityDomain(scaling='standard')
+        self.check_applicability_domain(model, 'pca-bounding-box-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -61,8 +61,7 @@ class TestAPI(unittest.TestCase):
         self.check_applicability_domain(model, 'convex-hull-ad.json')
         
     def test_pca_bounding_box_applicability_domain(self):
-        # TODO add robust scaler and maxabsscaler to ml2json
-        model = PCABoundingBoxApplicabilityDomain(scaling='standard')
+        model = PCABoundingBoxApplicabilityDomain()
         self.check_applicability_domain(model, 'pca-bounding-box-ad.json')
         
     def test_topkat_applicability_domain(self):

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -67,3 +67,11 @@ class TestAPI(unittest.TestCase):
     def test_topkat_applicability_domain(self):
         model = TopKatApplicabilityDomain()
         self.check_applicability_domain(model, 'topkat-ad.json')
+        
+    def test_leverage_applicability_domain(self):
+        model = LeverageApplicabilityDomain()
+        self.check_applicability_domain(model, 'leverage-ad.json')
+        
+    def test_hotelling_t2_applicability_domain(self):
+        model = HotellingT2ApplicabilityDomain()
+        self.check_applicability_domain(model, 'hotelling-t2-ad.json')

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -75,3 +75,8 @@ class TestAPI(unittest.TestCase):
     def test_hotelling_t2_applicability_domain(self):
         model = HotellingT2ApplicabilityDomain()
         self.check_applicability_domain(model, 'hotelling-t2-ad.json')
+        
+    # TODO add kde to ml2json
+    # def test_kernel_density_applicability_domain(self):
+    #     model = KernelDensityApplicabilityDomain()
+    #     self.check_applicability_domain(model, 'kernel-density-ad.json')

--- a/test/test_neighbors.py
+++ b/test/test_neighbors.py
@@ -5,7 +5,7 @@ import unittest
 
 import numpy as np
 from sklearn.datasets import load_iris
-from sklearn.neighbors import NearestNeighbors, KDTree
+from sklearn.neighbors import NearestNeighbors, KDTree, KernelDensity
 
 # Allow testing of additional optional dependencies
 __optionals__ = []
@@ -44,6 +44,28 @@ class TestAPI(unittest.TestCase):
 
     def test_nearest_neighbors(self):
         self.check_nearest_neighbors_model(NearestNeighbors(), 'nearest-neighbors.json')
+        
+    def check_kernel_density_model(self, model, model_name):
+        model.fit(self.data)
+
+        rng = np.random.RandomState(1234)
+        subset = self.data[rng.randint(self.data.shape[0], size=10)]
+        expected_ft = model.score_samples(subset)
+
+        serialized_dict_model = ml2json.to_dict(model)
+        deserialized_dict_model = ml2json.from_dict(serialized_dict_model)
+
+        ml2json.to_json(model, model_name)
+        deserialized_json_model = ml2json.from_json(model_name)
+        os.remove(model_name)
+
+        for deserialized_model in [deserialized_dict_model, deserialized_json_model]:
+            actual_ft = deserialized_model.score_samples(subset)
+
+            np.testing.assert_array_almost_equal(expected_ft, actual_ft) 
+        
+    def test_kernel_density(self):
+        self.check_kernel_density_model(KernelDensity(), 'kernel-density.json')
 
     def check_kdtree_model(self, model, model_name):
         rng = np.random.RandomState(1234)

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -7,7 +7,7 @@ import numpy as np
 from sklearn.datasets import fetch_california_housing
 from sklearn.preprocessing import (LabelEncoder, LabelBinarizer, MultiLabelBinarizer,
                                    MinMaxScaler, StandardScaler, KernelCenterer,
-                                   OneHotEncoder)
+                                   OneHotEncoder, RobustScaler, MaxAbsScaler)
 from sklearn.metrics.pairwise import pairwise_kernels
 
 from src import ml2json
@@ -118,6 +118,15 @@ class TestAPI(unittest.TestCase):
         self.check_scaler(StandardScaler(with_mean=False), 'standard-scaler.json')
         self.check_scaler(StandardScaler(with_std=False), 'standard-scaler.json')
         self.check_scaler(StandardScaler(with_mean=False, with_std=False), 'standard-scaler.json')
+
+    def test_robust_scaler(self):
+        self.check_scaler(RobustScaler(), 'robust-scaler.json')
+        self.check_scaler(RobustScaler(with_centering=False), 'robust-scaler.json')
+        self.check_scaler(RobustScaler(with_scaling=False), 'robust-scaler.json')
+        self.check_scaler(RobustScaler(with_centering=False, with_scaling=False), 'robust-scaler.json')
+        
+    def test_maxabs_scaler(self):
+        self.check_scaler(MaxAbsScaler(), 'maxabs-scaler.json')
 
     def check_centerer(self, centerer, model_name):
         expected_ft = centerer.fit_transform(self.kernel_X)


### PR DESCRIPTION
**Description**
This pull request incorporates all MLChemAD `ApplicabilityDomain` classes into ml2json.
		
**Changes**
		
- Added support for MLChemAD applicability domains.
- Added preprocessing.RobustScaler and preprocessing.MaxAbsScaler
- Added neighbors.KernelDensity
- Marked KNeigborsRegressor and KNeighborsClassifier as supported in the list of supported models (I believe they are already supported).