### PR TITLE
Add support scikit-learn <1.4.0 and add GitHub Actions workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,11 +1,10 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# This workflow will install Python dependencies and run tests
 
 name: Python package
 
 on:
   push:
-    branches: [ "feature/ci" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[full]"  --no-cache-dir
+    - name: Test with unittest
+      run: |
+        python -m unittest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "feature/ci" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In addition of the support for scikit-learn models, ml2json supports the followi
 - Prince
 - MlChemAD
 
-ml2json requires scikit-learn >= 0.21.3.
+ml2json requires scikit-learn >= 1.2.2, <=1.4.0.
 
 ## Supported scikit-learn Models
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages = find:
 package_dir =
     = src
 install_requires =
-    scikit-learn>=1.4.0
+    scikit-learn>=1.2.2, <=1.4.0
     scipy
     joblib
 

--- a/src/ml2json/regression.py
+++ b/src/ml2json/regression.py
@@ -336,16 +336,29 @@ def serialize_gradient_boosting_regressor(model):
     elif isinstance(model.init_, str):
         serialized_model['init_'] = model.init_
 
-    if isinstance(model._loss, loss.HalfSquaredError):
-        serialized_model['_loss'] = 'ls'
-    elif isinstance(model._loss, loss.AbsoluteError):
-        serialized_model['_loss'] = 'lad'
-    elif isinstance(model._loss, loss.HuberLoss):
-        serialized_model['_loss'] = 'huber'
-        serialized_model['quantile'] = model._loss.quantile
-    elif isinstance(model._loss, loss.PinballLoss):
-        serialized_model['_loss'] = 'quantile'
-        serialized_model['quantile'] = model._loss.closs.quantile
+    if sklearn.__version__ >= '1.4.0':
+        if isinstance(model._loss, loss.HalfSquaredError):
+            serialized_model['_loss'] = 'ls'
+        elif isinstance(model._loss, loss.AbsoluteError):
+            serialized_model['_loss'] = 'lad'
+        elif isinstance(model._loss, loss.HuberLoss):
+            serialized_model['_loss'] = 'huber'
+            serialized_model['quantile'] = model._loss.quantile
+        elif isinstance(model._loss, loss.PinballLoss):
+            serialized_model['_loss'] = 'quantile'
+            serialized_model['quantile'] = model._loss.closs.quantile
+    else:
+        from sklearn.ensemble import _gb_losses
+        if isinstance(model._loss, _gb_losses.LeastSquaresError):
+            serialized_model['_loss'] = 'ls'
+        elif isinstance(model._loss, _gb_losses.LeastAbsoluteError):
+            serialized_model['_loss'] = 'lad'
+        elif isinstance(model._loss, _gb_losses.HuberLossFunction):
+            serialized_model['_loss'] = 'huber'
+        elif isinstance(model._loss, _gb_losses.QuantileLossFunction):
+            serialized_model['quantile'] = model._loss.quantile
+        elif isinstance(model._loss, loss.PinballLoss):
+            serialized_model['_loss'] = 'quantile'
 
     if 'priors' in model.init_.__dict__:
         serialized_model['priors'] = model.init_.priors.tolist()
@@ -375,14 +388,26 @@ def deserialize_gradient_boosting_regressor(model_dict):
     model.train_score_ = np.array(model_dict['train_score_'])
     model.max_features_ = model_dict['max_features_']
     model.n_features_in_ = model_dict['n_features_in_']
-    if model_dict['_loss'] == 'ls':
-        model._loss = loss.HalfSquaredError()
-    elif model_dict['_loss'] == 'lad':
-        model._loss = loss.AbsoluteError()
-    elif model_dict['_loss'] == 'huber':
-        model._loss = loss.HuberLoss(quantile=model_dict['quantile'])
-    elif model_dict['_loss'] == 'quantile':
-        model._loss = loss.PinballLoss(quantile=model_dict['quantile'])
+    
+    if sklearn.__version__ >= '1.4.0':
+        if model_dict['_loss'] == 'ls':
+            model._loss = loss.HalfSquaredError()
+        elif model_dict['_loss'] == 'lad':
+            model._loss = loss.AbsoluteError()
+        elif model_dict['_loss'] == 'huber':
+            model._loss = loss.HuberLoss(quantile=model_dict['quantile'])
+        elif model_dict['_loss'] == 'quantile':
+            model._loss = loss.PinballLoss(quantile=model_dict['quantile'])
+    else:
+        from sklearn.ensemble import _gb_losses
+        if model_dict['_loss'] == 'ls':
+            model._loss = _gb_losses.LeastSquaresError()
+        elif model_dict['_loss'] == 'lad':
+            model._loss = _gb_losses.LeastAbsoluteError()
+        elif model_dict['_loss'] == 'huber':
+            model._loss = _gb_losses.HuberLossFunction(1)
+        elif model_dict['_loss'] == 'quantile':
+            model._loss = _gb_losses.QuantileLossFunction(1)
 
     if 'priors' in model_dict:
         model.init_.priors = np.array(model_dict['priors'])

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -165,7 +165,7 @@ class TestAPI(unittest.TestCase):
 
     def test_xgboost_ranker(self):
         if 'XGBRanker' in __optionals__:
-            self.check_ranking_model(XGBRanker(), 'XGB-ranker.json')
+            self.check_ranking_model(XGBRanker(ndcg_exp_gain=False), 'XGB-ranker.json')
 
     def test_xgboost_regressor(self):
         if 'XGBRegressor' in __optionals__:


### PR DESCRIPTION
This pull request adds support for scikit-learn versions earlier than 1.4.0 and includes the addition of a GitHub Actions workflow for automated testing.

Changes:

- Change gradient boost serialization to work with sklearn < 1.4.0
- Change requirements in setup.cfg (sklearn => 1.2.2 and sklearn <= 1.4.0)
- Remove specification of version in readme
- Add basic GitHub workflow to run unit tests