### PR TITLE
Save PCABoundingBoxApplicabilityDomain with none scaling

### DIFF
--- a/src/ml2json/applicability_domain.py
+++ b/src/ml2json/applicability_domain.py
@@ -103,7 +103,7 @@ def serialize_pca_bounding_box_applicability_domain(model):
     serialized_model = {
         'meta': 'pca-bounding-box-ad',
         'fitted_': model.fitted_,
-        'scaler': ml2json.to_dict(model.scaler),
+        'scaler': ml2json.to_dict(model.scaler) if model.scaler is not None else None,
         'min_explained_var': model.min_explained_var,
         'pca': ml2json.to_dict(model.pca),
     }
@@ -123,7 +123,8 @@ if 'PCABoundingBoxApplicabilityDomain' in __optionals__:
     def deserialize_pca_bounding_box_applicability_domain(model_dict):
         model = PCABoundingBoxApplicabilityDomain()
         model.fitted_ = model_dict['fitted_']
-        model.scaler = ml2json.from_dict(model_dict['scaler'])
+        model.scaler = (ml2json.from_dict(model_dict['scaler'])
+                        if model_dict['scaler'] is not None else None)
         model.min_explained_var = model_dict['min_explained_var']
         model.pca = ml2json.from_dict(model_dict['pca'])
 

--- a/test/test_applicability_domain.py
+++ b/test/test_applicability_domain.py
@@ -82,6 +82,10 @@ class TestAPI(unittest.TestCase):
     def test_pca_bounding_box_applicability_domain(self):
         model = PCABoundingBoxApplicabilityDomain()
         self.check_applicability_domain(model, 'pca-bounding-box-ad.json')
+        
+        # check with scaling is None
+        model = PCABoundingBoxApplicabilityDomain(scaling=None)
+        self.check_applicability_domain(model, 'pca-bounding-box-ad.json')
 
     @unittest.skipIf(len(__optionals__) == 0, 'Optional dependencies not installed.')
     def test_topkat_applicability_domain(self):


### PR DESCRIPTION
Ensures `PCABoundingBoxApplicabilityDomain` with None scaling is correctly serialized, which is added in https://github.com/OlivierBeq/MLChemAD/pull/2.