### PR TITLE
fix TypeError: len() of unsized object

### DIFF
--- a/src/ml2json/preprocessing.py
+++ b/src/ml2json/preprocessing.py
@@ -88,7 +88,7 @@ def deserialize_minmax_scaler(model_dict):
     model.n_samples_seen_ = model_dict['n_samples_seen_']
 
     if 'feature_names_in_' in model_dict.keys():
-        model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+        model.feature_names_in_ = np.array(model_dict['feature_names_in_'])
 
     return model
 
@@ -145,7 +145,7 @@ def deserialize_standard_scaler(model_dict):
         model.n_samples_seen_ = model_dict['n_samples_seen_']
 
     if 'feature_names_in_' in model_dict.keys():
-        model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+        model.feature_names_in_ = np.array(model_dict['feature_names_in_'])
 
     return model
 
@@ -189,7 +189,7 @@ def deserialize_robust_scaler(model_dict):
             model.center_ = model_dict['center_']
 
     if 'feature_names_in_' in model_dict.keys():
-        model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+        model.feature_names_in_ = np.array(model_dict['feature_names_in_'])
 
     return model
 
@@ -220,7 +220,7 @@ def deserialize_maxabs_scaler(model_dict):
     if 'n_features_in_' in model_dict.keys():
         model.n_features_in_ = model_dict['n_features_in_']
     if 'feature_names_in_' in model_dict.keys():
-        model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+        model.feature_names_in_ = np.array(model_dict['feature_names_in_'])
     if 'n_samples_seen_' in model_dict.keys():
         model.n_samples_seen_ = model_dict['n_samples_seen_']
     if 'max_abs_' in model_dict.keys():
@@ -402,6 +402,6 @@ def deserialize_normalizer(model_dict):
     if 'n_features_in_' in model_dict.keys():
         model.n_features_in_ = model_dict['n_features_in_']
     if 'feature_names_in_' in model_dict.keys():
-        model.feature_names_in_ = np.array(model_dict['feature_names_in_'][0])
+        model.feature_names_in_ = np.array(model_dict['feature_names_in_'])
 
     return model

--- a/test/test_preprocessing.py
+++ b/test/test_preprocessing.py
@@ -38,7 +38,7 @@ class TestAPI(unittest.TestCase):
         self.simple_test_data = [0, 1, 2, 1]
         self.simple_test_labels = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1], [0, 1, 0]])
 
-        self.X = fetch_california_housing()['data']
+        self.X = fetch_california_housing(as_frame=True)['data']
         self.kernel_X = pairwise_kernels(self.X[:100], metric="linear", filter_params=True, degree=3, coef0=1)
 
     def check_model(self, model, model_name, data, labels):


### PR DESCRIPTION
Hi @OlivierBeq,
 
An error occurs when standardizing pandas dataframes after reloading a saved standardizer with version 0.5.0:
 
 ```
python3.11/site-packages/sklearn/base.py:608: in _validate_data
    self._check_feature_names(X, reset=reset)
        # validate the feature names against the `feature_names_in_` attribute
>       if len(fitted_feature_names) != len(X_feature_names) or np.any(
            fitted_feature_names != X_feature_names
        ):
E       TypeError: len() of unsized object
```

This error occurs because of the removal of the "," after `model.feature_names_in_.tolist()` in the scaler serialization in commit 806a305.
It was fixed by removing the `[0]` after ` np.array(model_dict['feature_names_in_'])` in the deserialization of the scalers.

I also changed the test data from an numpy array to a pandas dataframe, so the error occurs in the tests without the fix.